### PR TITLE
Issue using Sinatra 1.0 with Ruby 1.9.2

### DIFF
--- a/faceboku.rb
+++ b/faceboku.rb
@@ -1,6 +1,9 @@
 require 'sinatra'
 require 'omniauth/oauth'
 
+# workaround for ruby 1.9.2 with sinatra 1.0. See: http://stackoverflow.com/questions/3973402/sinatra-app-doesnt-start-on-run
+enable :run
+
 enable :sessions
 
 APP_ID = "153304591365687"


### PR DESCRIPTION
Hola Rafael

I failed running faceboku and found out that there is an issue using Sinatra 1.0 with Ruby 1.9.2. Check http://stackoverflow.com/questions/3973402/sinatra-app-doesnt-start-on-run

I added 'enable :run' and now the application starts. It might make sense to pull this one because you explicitly mention using Ruby 1.9.x with RVM (exactly the setup I have).

Saludos
Javier

P.S.: I do have the following error when starting the app in the browser, but I guess that has nothing to do with your implementation?

Errno::ENOENT at /
No such file or directory - /Users/javier/Workspace/Faceboku/<internal:lib/rubygems/views/index.erb
